### PR TITLE
fix: yearly bond & quarterly bond coupon dates

### DIFF
--- a/contracts/facets/BondFacet.sol
+++ b/contracts/facets/BondFacet.sol
@@ -183,7 +183,7 @@ contract BondFacet is BondStorage, OwnershipFacet, IERC1155Receiver, ERC165 {
                 }
             } else if (_bondDetails.__periodicity == Periodicity.Quarterly) {
                 if (i == 0) {
-                    if (month >= 11) {
+                    if (month >= 10) {
                         couponYear = year + 1;
                     } else {
                         couponYear = year;
@@ -203,13 +203,8 @@ contract BondFacet is BondStorage, OwnershipFacet, IERC1155Receiver, ERC165 {
                 }
             } else if (_bondDetails.__periodicity == Periodicity.Annual) {
                 if (i == 0) {
-                    if (month == 12) {
-                        couponYear = year + 1;
-                    }
-                    couponMonth = (month) % 12;
-                    if (couponMonth == 0) {
-                        couponMonth = 12;
-                    }
+                    couponYear = year;
+                    couponMonth = month;
                 } else {
                     couponYear = couponYear + 1;
                 }


### PR DESCRIPTION
## Summary by Sourcery

Fix coupon calculation for yearly and quarterly bonds.

Bug Fixes:
- Correct the month used to calculate coupon payments for quarterly bonds.
- Set the correct year and month for yearly bond coupon payments.